### PR TITLE
u-boot-ota: fix build error under gcc6

### DIFF
--- a/recipes-bsp/u-boot/u-boot-ota/fix-build-error-under-gcc6.patch
+++ b/recipes-bsp/u-boot/u-boot-ota/fix-build-error-under-gcc6.patch
@@ -1,0 +1,86 @@
+fix build error under gcc6
+
+Fix the following error:
+| ../include/linux/compiler-gcc.h:114:30: fatal error: linux/compiler-gcc6.h: No such file or directory
+|  #include gcc_header(__GNUC__)
+
+Signed-off-by: Zhenhua Luo <zhenhua.luo@nxp.com>
+
+Upstream-Status: Pending
+---
+ include/linux/compiler-gcc6.h | 65 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+ create mode 100644 include/linux/compiler-gcc6.h
+
+diff --git a/include/linux/compiler-gcc6.h b/include/linux/compiler-gcc6.h
+new file mode 100644
+index 0000000..c8c5659
+--- /dev/null
++++ b/include/linux/compiler-gcc6.h
+@@ -0,0 +1,65 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc5.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   Early snapshots of gcc 4.3 don't support this and we can't detect this
++   in the preprocessor, but we can live with this because they're unreleased.
++   Maketime probing would be overkill here.
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
+-- 

--- a/recipes-bsp/u-boot/u-boot-ota_2015.07.bb
+++ b/recipes-bsp/u-boot/u-boot-ota_2015.07.bb
@@ -11,6 +11,7 @@ SRCREV = "baba2f57e8f4ed3fa67fe213d22da0de5e00f204"
 
 SRC_URI += "file://0001-Set-up-environment-for-OSTree-integration.patch \
 	    file://0002-Replace-wraps-with-built-in-code-to-remove-dependenc.patch \
+	    file://fix-build-error-under-gcc6.patch \
 	    "
 
 PV = "v2015.07+git${SRCPV}"


### PR DESCRIPTION
Fix the following build error under gcc6:
| ../include/linux/compiler-gcc.h:114:30: fatal error: linux/compiler-gcc6.h: No such file or directory
|  #include gcc_header(__GNUC__)

This was needed to complete a build  of the ATS Garage Quickstart with architecture set to qemux86-64. The same resolution was widely applied by other bsp layers relying on 2015 u-boot releases.

Signed-off-by: Andrea Galbusera <gizero@gmail.com>