### PR TITLE
Force emulated cpu to Haswell

### DIFF
--- a/scripts/run-qemu
+++ b/scripts/run-qemu
@@ -96,6 +96,8 @@ class QemuCommand(object):
             cmdline.append('-nographic')
         if self.kvm:
             cmdline.append('-enable-kvm')
+        else:
+            cmdline += ['-cpu', 'Haswell']
         return cmdline
 
 


### PR DESCRIPTION
By default AGL uses instructions that are only on Haswell.  This causes invalid
instruction errors when running with --no-kvm.