### PR TITLE
local.conf.sample: Add extra free disk space

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -239,3 +239,6 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Add extra free disk space to ensure that updates can be installed
+IMAGE_ROOTFS_EXTRA_SPACE = "65536"
+


### PR DESCRIPTION
Add extra free disk space to ensure that updates
on QEMU can be successfully installed.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>