### PR TITLE
Fix typo (minnowboard instead of qemux86-64).

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,7 +5,7 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "updater-minnowboard"
-BBFILE_PATTERN_updater-minnowboard = "^${LAYERDIR}/"
-BBFILE_PRIORITY_updater-minnowboard = "7"
+BBFILE_COLLECTIONS += "updater-qemux86-64"
+BBFILE_PATTERN_updater-qemux86-64 = "^${LAYERDIR}/"
+BBFILE_PRIORITY_updater-qemux86-64 = "7"
 


### PR DESCRIPTION
Presumably just a copy-paste error from when this was written in 2016.