### PR TITLE
Fix u-boot support for 2018.07

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Set-up-environment-for-OSTree-integration.patch
+++ b/recipes-bsp/u-boot/files/0001-Set-up-environment-for-OSTree-integration.patch
@@ -1,22 +1,24 @@
-From 855282cc487f2afa6771d33b0d036ad637e87d1b Mon Sep 17 00:00:00 2001
-From: Leon Anavi <leon.anavi@konsulko.com>
-Date: Tue, 20 Feb 2018 19:31:55 +0200
+From 6c1f0bd556ce99b5eb2bab9093daa5276f275ee2 Mon Sep 17 00:00:00 2001
+From: Laurent Bonnans <laurent.bonnans@here.com>
+Date: Fri, 20 Jul 2018 16:09:20 +0200
 Subject: [PATCH] qemu-x86.h: Set up environment for OSTree integration
 
-Rebase Anton's patch for setting up envieronment
-for OSTree integration for QEMU.
+Setup environment for QEMU OSTree integration
+
+Includes fix for u-boot 2018.07 (explicit IDE initialization)
 
 Co-Authored-By: Anton Gerasimov <anton@advancedtelematic.com>
-Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+Co-Authored-By: Leon Anavi <leon.anavi@konsulko.com>
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
 ---
  include/configs/qemu-x86.h | 21 +++++++++++++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/include/configs/qemu-x86.h b/include/configs/qemu-x86.h
-index 01072f8..755fb65 100644
+index 4b9ddd6f25..ff4b1d14d6 100644
 --- a/include/configs/qemu-x86.h
 +++ b/include/configs/qemu-x86.h
-@@ -45,4 +45,25 @@
+@@ -42,4 +42,25 @@
  #define CONFIG_SPL_BOARD_LOAD_IMAGE
  #define BOOT_DEVICE_BOARD		11
  
@@ -28,7 +30,7 @@ index 01072f8..755fb65 100644
 +#define CONFIG_BOOTDELAY 3
 +
 +#undef CONFIG_BOOTCOMMAND
-+#define CONFIG_BOOTCOMMAND "run loadenv;" \
++#define CONFIG_BOOTCOMMAND "ide reset; run loadenv;" \
 +			   "setenv bootargs $bootargs\" console=ttyS0 root=/dev/ram0 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/hda ramdisk_size=16384 \";" \
 +			   "ext2load ide 0 $loadaddr \"/boot\"$kernel_image;" \
 +			   "ext2load ide 0 $ramdiskaddr \"/boot\"$ramdisk_image;" \
@@ -43,5 +45,5 @@ index 01072f8..755fb65 100644
 +
  #endif	/* __CONFIG_H */
 -- 
-2.7.4
+2.18.0
 


### PR DESCRIPTION
IDE subsystem must now be reset manually before fs operations

See: https://git.denx.de/?p=u-boot.git;a=commit;h=ec15d5f6e5e4bb718d58ec2a3753ae95abc18279