### PR TITLE
Fix u-boot build with poky master

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -6,6 +6,8 @@ SRC_URI +=" \
             file://0001-Set-up-environment-for-OSTree-integration.patch \
           "
 
+# fix after default security flags in poky
+TOOLCHAIN_OPTIONS_append = "${SECURITY_NOPIE_CFLAGS}"
 
 do_compile_prepend() {
   export BUILD_ROM=y


### PR DESCRIPTION
The poky commit 491082c56ce34f3fd644f8d4457ccd52af951087 which enables
PIE by default on GCC breaks our u-boot builds.

So, explicitly compile u-boot with the options which disable it