### PR TITLE
Refresh u-boot patch for 2019.07

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Set-up-environment-for-OSTree-integration.patch
+++ b/recipes-bsp/u-boot/files/0001-Set-up-environment-for-OSTree-integration.patch
@@ -1,4 +1,4 @@
-From 6c1f0bd556ce99b5eb2bab9093daa5276f275ee2 Mon Sep 17 00:00:00 2001
+From e8fbb1628628c69bb0b87c7824d2646492a66385 Mon Sep 17 00:00:00 2001
 From: Laurent Bonnans <laurent.bonnans@here.com>
 Date: Fri, 20 Jul 2018 16:09:20 +0200
 Subject: [PATCH] qemu-x86.h: Set up environment for OSTree integration
@@ -10,17 +10,18 @@ Includes fix for u-boot 2018.07 (explicit IDE initialization)
 Co-Authored-By: Anton Gerasimov <anton@advancedtelematic.com>
 Co-Authored-By: Leon Anavi <leon.anavi@konsulko.com>
 Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+
 ---
  include/configs/qemu-x86.h | 21 +++++++++++++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/include/configs/qemu-x86.h b/include/configs/qemu-x86.h
-index 4b9ddd6f25..ff4b1d14d6 100644
+index 64e7a60b8a..c86d256aa7 100644
 --- a/include/configs/qemu-x86.h
 +++ b/include/configs/qemu-x86.h
-@@ -42,4 +42,25 @@
+@@ -35,4 +35,25 @@
+ 
  #define CONFIG_SPL_BOARD_LOAD_IMAGE
- #define BOOT_DEVICE_BOARD		11
  
 +#undef CONFIG_BOOTARGS
 +
@@ -44,6 +45,3 @@ index 4b9ddd6f25..ff4b1d14d6 100644
 +				  "loadenv=if ext2load ide 0 $loadaddr /boot/loader/uEnv.txt; then env import -t $loadaddr $filesize; fi;"
 +
  #endif	/* __CONFIG_H */
--- 
-2.18.0
-


### PR DESCRIPTION
Patch applied with fuzz. Silences this warning:

    WARNING: u-boot-1_2019.07-r0 do_patch: Fuzz detected:

    Applying patch 0001-Set-up-environment-for-OSTree-integration.patch
    patching file include/configs/qemu-x86.h
    Hunk #1 succeeded at 35 with fuzz 2 (offset -7 lines).