### PR TITLE
u-boot: only patch when building for qemu machines

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -9,7 +9,7 @@ SRC_URI +=" \
 # fix after default security flags in poky
 TOOLCHAIN_OPTIONS_append = "${SECURITY_NOPIE_CFLAGS}"
 
-do_compile_prepend() {
+do_compile_prepend_qemux86-64 () {
   export BUILD_ROM=y
 }
-UBOOT_SUFFIX = "rom"
+UBOOT_SUFFIX_qemux86-64 = "rom"


### PR DESCRIPTION
This should allow removing this hack: https://github.com/advancedtelematic/meta-updater/blob/22165a78b34583c1389c0c9c5841c5377bad6e10/lib/oeqa/selftest/cases/updater_raspberrypi.py#L32