### PR TITLE
u-boot: Revert a commit that changed default define values.

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Revert-ide-remove-duplicate-defines-form-include-ata.patch
+++ b/recipes-bsp/u-boot/files/0001-Revert-ide-remove-duplicate-defines-form-include-ata.patch
@@ -1,0 +1,65 @@
+From 2c14e6c38271418f7ff9d8474e11406d85f9e845 Mon Sep 17 00:00:00 2001
+From: Patrick Vacek <patrickvacek@gmail.com>
+Date: Thu, 30 Jul 2020 13:10:51 +0200
+Subject: [PATCH] Revert "ide: remove duplicate defines form include/ata.h"
+
+This reverts commit 04571bec56a53c846f072fb3bc7543586f10ee93.
+
+Supposedly, the defines that were removed were redundant, but the
+default values were in fact different, and we depend on the versions
+that were removed.
+---
+ include/ata.h | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/include/ata.h b/include/ata.h
+index 3d870c973f..d8a0275630 100644
+--- a/include/ata.h
++++ b/include/ata.h
+@@ -67,9 +67,43 @@
+ #endif /* ATA_DEVICE */
+ #define ATA_LBA		0xE0
+ 
++/*
++ * ATA Commands (only mandatory commands listed here)
++ */
++#define ATA_CMD_READ	0x20	/* Read Sectors (with retries)	*/
++#define ATA_CMD_READN	0x21	/* Read Sectors ( no  retries)	*/
++#define ATA_CMD_WRITE	0x30	/* Write Sectores (with retries)*/
++#define ATA_CMD_WRITEN	0x31	/* Write Sectors  ( no  retries)*/
++#define ATA_CMD_VRFY	0x40	/* Read Verify  (with retries)	*/
++#define ATA_CMD_VRFYN	0x41	/* Read verify  ( no  retries)	*/
++#define ATA_CMD_SEEK	0x70	/* Seek				*/
++#define ATA_CMD_DIAG	0x90	/* Execute Device Diagnostic	*/
++#define ATA_CMD_INIT	0x91	/* Initialize Device Parameters	*/
++#define ATA_CMD_RD_MULT	0xC4	/* Read Multiple		*/
++#define ATA_CMD_WR_MULT	0xC5	/* Write Multiple		*/
++#define ATA_CMD_SETMULT	0xC6	/* Set Multiple Mode		*/
++#define ATA_CMD_RD_DMA	0xC8	/* Read DMA (with retries)	*/
++#define ATA_CMD_RD_DMAN	0xC9	/* Read DMS ( no  retries)	*/
++#define ATA_CMD_WR_DMA	0xCA	/* Write DMA (with retries)	*/
++#define ATA_CMD_WR_DMAN	0xCB	/* Write DMA ( no  retires)	*/
++#define ATA_CMD_IDENT	0xEC	/* Identify Device		*/
++#define ATA_CMD_SETF	0xEF	/* Set Features			*/
++#define ATA_CMD_CHK_PWR	0xE5	/* Check Power Mode		*/
++
++#define ATA_CMD_READ_EXT 0x24	/* Read Sectors (with retries)	with 48bit addressing */
++#define ATA_CMD_WRITE_EXT	0x34	/* Write Sectores (with retries) with 48bit addressing */
++#define ATA_CMD_VRFY_EXT	0x42	/* Read Verify	(with retries)	with 48bit addressing */
++
++#define ATA_CMD_FLUSH 0xE7 /* Flush drive cache */
++#define ATA_CMD_FLUSH_EXT 0xEA /* Flush drive cache, with 48bit addressing */
++
+ /*
+  * ATAPI Commands
+  */
++#define ATAPI_CMD_IDENT 0xA1 /* Identify AT Atachment Packed Interface Device */
++#define ATAPI_CMD_PACKET 0xA0 /* Packed Command */
++
++
+ #define ATAPI_CMD_INQUIRY 0x12
+ #define ATAPI_CMD_REQ_SENSE 0x03
+ #define ATAPI_CMD_READ_CAP 0x25
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -4,6 +4,7 @@ DEPENDS += "swig-native"
 
 SRC_URI +=" \
             file://0001-Set-up-environment-for-OSTree-integration.patch \
+            file://0001-Revert-ide-remove-duplicate-defines-form-include-ata.patch \
           "
 
 # fix after default security flags in poky


### PR DESCRIPTION
Something about the previously default values was actually necessary for our needs. I haven't determined specifically which one it was, but for now, simply reverting the commit appears to work.