### PR TITLE
layer.conf: add gatesgarth to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_updater-qemux86-64 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_updater-qemux86-64 = "7"
 
 LAYERDEPENDS_updater-qemux86-64 = "sota"
-LAYERSERIES_COMPAT_updater-qemux86-64 = "dunfell"
+LAYERSERIES_COMPAT_updater-qemux86-64 = "dunfell gatesgarth"


### PR DESCRIPTION
bitbake does not work for master after gatesgarth release. fix it
Signed-off-by: Anatoliy Odukha <aodukha@gmail.com>